### PR TITLE
Increase DisplayBoard ETA to 60 minutes

### DIFF
--- a/src/main/java/dev/ithundxr/railwaystweaks/mixin/compat/create/StationSummaryDisplaySourceMixin.java
+++ b/src/main/java/dev/ithundxr/railwaystweaks/mixin/compat/create/StationSummaryDisplaySourceMixin.java
@@ -1,0 +1,44 @@
+package dev.ithundxr.railwaystweaks.mixin.compat.create;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.simibubi.create.content.redstone.displayLink.source.DisplaySource;
+import com.simibubi.create.content.redstone.displayLink.source.StationSummaryDisplaySource;
+import com.simibubi.create.content.trains.display.FlapDisplaySection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import static com.simibubi.create.content.trains.display.FlapDisplaySection.MONOSPACE;
+
+@Mixin(value = StationSummaryDisplaySource.class, remap = false)
+public abstract class StationSummaryDisplaySourceMixin extends DisplaySource {
+
+    @ModifyExpressionValue(
+            method = "lambda$provideFlapDisplayText$0(ZLjava/util/List;Ljava/lang/String;Lcom/simibubi/create/content/trains/display/GlobalTrainDisplayData$TrainDeparturePrediction;)V",
+            at = @At(value = "CONSTANT", args = "intValue=11700"))
+    private static int increaseEtaDisplayLimitTo60m(int original) {
+        // increase max ETA time shown on Display Boards from 12000 ticks (10 min) to 72000 ticks (60 min)
+        return 72000 - 15 * 20;
+    }
+
+    @ModifyArg(method = "loadFlapDisplayLayout", at = @At(value = "INVOKE",
+            target = "Lcom/simibubi/create/content/trains/display/FlapDisplaySection;<init>(FLjava/lang/String;ZZ)V",
+            ordinal = 0
+    ),
+            index = 0)
+    private float doubleMinuteSectionWidth(float width) {
+        return MONOSPACE * 2; // double the width of the minute section
+    }
+
+    @ModifyVariable(method = "loadFlapDisplayLayout", at = @At("STORE"), name = "minutes")
+    private FlapDisplaySection setRightAlignedOnMinuteSection(FlapDisplaySection minutes) {
+        return minutes.rightAligned();
+    }
+
+    @ModifyVariable(method = "loadFlapDisplayLayout", at = @At("STORE"), name = "totalSize")
+    private float decreaseAvailableSpaceForOtherSections(float totalSize) {
+        return totalSize - MONOSPACE; // subtract the amount added above
+    }
+
+}

--- a/src/main/resources/railwaystweaks.mixins.json
+++ b/src/main/resources/railwaystweaks.mixins.json
@@ -18,6 +18,7 @@
     "compat.create.BasinRecipeMixin",
     "compat.create.CarriageBogeyMixin",
     "compat.create.ScheduleRuntimeMixin",
+    "compat.create.StationSummaryDisplaySourceMixin",
     "compat.create.TrainMixin",
     "compat.dcintegration.DiscordEventListenerMixin",
     "compat.dcintegration.FabricMessageUtilsMixin",


### PR DESCRIPTION
This Mixin increases the max ETA shown on display boards from 10 minutes to 60 minutes.
I've discussed this change with @sleepy-evelyn on Discord.
<img width="2560" height="1351" alt="image" src="https://github.com/user-attachments/assets/15c50c4a-4d1b-4832-92e2-6ab679bb1971" />

This is my first Mixin and Minecraft modification ever, so please review carefully.